### PR TITLE
cherry-pick-for: use awk instead of cut for utf delimiter

### DIFF
--- a/cherry-pick-for
+++ b/cherry-pick-for
@@ -41,9 +41,9 @@ if [ "${COMMITS:0:4}" = http ]; then
   if [ "$MERGE_COMMIT" = 1 ]; then
     TEMP_BRANCH="pick$RANDOM"
     META="$(curl -s -S -f -L "$URL" | grep '<title>.*GitHub</title>')"
-    PR_MSG1="Merge$(echo "$META" | cut -d '·' -f 2 | tr '[:upper:]' '[:lower:]')"
-    PR_MSG2="from$(echo "$META" | cut -d '·' -f 3)"
-    PR_TITLE="$(echo "$META" | cut -d '·' -f 1 | cut -d '>' -f 2- | rev | cut -d ' ' -f 4- | rev)"
+    PR_MSG1="Merge$(echo "$META" | awk -F'·' '{ print $2 }' | tr '[:upper:]' '[:lower:]')"
+    PR_MSG2="from$(echo "$META" | awk -F'·' '{ print $3 }')"
+    PR_TITLE="$(echo "$META" | awk -F'·' '{ print $1 }' | cut -d '>' -f 2- | rev | cut -d ' ' -f 4- | rev)"
     COMMIT_MSG="$PR_MSG1$PR_MSG2
 
 $PR_TITLE"


### PR DESCRIPTION
On my systems cut does not work with the unicode '·' character, and complains
that the delimiter must be a single character. Awk has no such problem.